### PR TITLE
Setup auto provisioning of EC2 instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
 - ./setup_aws_cli.sh
 script:
 - ./deploy_infra.sh
-- ./update_cf_stack.sh
+- ./create_cf_stack.sh

--- a/create_cf_stack.sh
+++ b/create_cf_stack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+STACK_NAME="ec2-jsmith"
+INSTANCE_TYPE="t2.nano"
+CF_TEMPLATE="ec2.yml"
+UPDATE_CMD="aws cloudformation create-stack \
+--stack-name $STACK_NAME \
+--capabilities CAPABILITY_NAMED_IAM \
+--on-failure DELETE \
+--notification-arns $CloudformationNotifyLambdaTopicArn \
+--template-body file://cf_templates/$CF_TEMPLATE \
+--parameters \
+ParameterKey=VpcName,ParameterValue="computevpc" \
+ParameterKey=VpcSubnet,ParameterValue="PrivateSubnet" \
+ParameterKey=KeyName,ParameterValue="scicomp" \
+ParameterKey=InstanceType,ParameterValue=\"$INSTANCE_TYPE\" \
+ParameterKey=JcServiceApiKey,ParameterValue=\"$JcServiceApiKey\" \
+ParameterKey=JcSystemsGroupId,ParameterValue=\"$JcSystemsGroupId\" \
+ParameterKey=JcConnectKey,ParameterValue=\"$JcConnectKey\""
+message=$($UPDATE_CMD 2>&1 1>/dev/null)
+error_code=$(echo $?)
+if [[ $error_code -ne 0 && $message =~ .*"AlreadyExistsException".* ]]; then
+  error_code=0
+elif [[ $error_code -ne 0 ]]; then
+  echo $message
+  exit $error_code
+else
+  echo -e "\nCreating stack $STACK_NAME with template cf_templates/$CF_TEMPLATE"
+fi


### PR DESCRIPTION
Allow travis to provision EC2 instances when new stacks
are added to create_cf_stack.sh script.

Workflow:
1. git checkout -b new-instance
2. User (jsmith) adds a new stack to create_cf_stack.sh file.
3. git commit -a -m "create instance for anxiety study"
4. git push origin new-instance
5. Create a PR on github
6. Have someone review and approve the PR
7. PR is approved and merged
8. Travis provisions a new EC2 instance
9. jsmith can now login with his jumpcloud credentials