### PR TITLE
Lambda to cleanup jumpcloud systems

### DIFF
--- a/cf_templates/jumpcloud.yml
+++ b/cf_templates/jumpcloud.yml
@@ -1,0 +1,67 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Create a lambda function to periodically clean up jumpcloud systems
+Metadata: {}
+Parameters:
+  JcServiceApiKey:
+    Description: The Jumpcloud service user API key
+    Type: String
+    NoEcho: true
+Resources:
+  JumpcloudCleanSystems:
+    DependsOn:
+      - LambdaExecutionRole
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: clean_systems.lambda_handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python2.7
+      Timeout: '10'
+      Environment:
+        Variables:
+          JC_SERVICE_API_KEY: !Ref JcServiceApiKey
+      Code:
+        S3Bucket: "essentials-awss3lambdaartifactsbucket-1ef8sqdil160e"
+        S3Key: "scicomp-infra/master/jumpcloud.zip"
+  PeriodicEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: "rate(1 hour)"
+      Targets:
+        - Arn: !GetAtt JumpcloudCleanSystems.Arn
+          Id: !Ref JumpcloudCleanSystems
+  LambdaExecutionRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: 'arn:aws:logs:*:*:*'
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt JumpcloudCleanSystems.Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt PeriodicEvent.Arn
+Outputs:
+  JumpcloudCleanSystems:
+    Value: !Ref JumpcloudCleanSystems
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-JumpcloudCleanSystems'

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -119,3 +119,24 @@ else
   echo $message
 fi
 
+STACK_NAME="jc-clean-systems"
+CF_TEMPLATE="jumpcloud.yml"
+echo -e "\nUpdating $STACK_NAME with template cf_templates/$CF_TEMPLATE"
+UPDATE_CMD="aws cloudformation update-stack \
+--stack-name $STACK_NAME \
+--capabilities CAPABILITY_NAMED_IAM \
+--notification-arns $CloudformationNotifyLambdaTopicArn \
+--template-body file://cf_templates/$CF_TEMPLATE \
+--parameters \
+ParameterKey=JcServiceApiKey,ParameterValue=\"$JcServiceApiKey\""
+message=$($UPDATE_CMD 2>&1 1>/dev/null)
+error_code=$(echo $?)
+if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
+  echo -e "\nNo stack changes detected. An update is not required."
+  error_code=0
+elif [[ $error_code -ne 0 ]]; then
+  echo $message
+  exit $error_code
+else
+  echo $message
+fi


### PR DESCRIPTION
A resource (i.e. EC2 instance) is provisioned with a CF stack and it
gets registered as a "system" in jumpcloud.  When the resource is removed
from AWS (via a stack delete) it will continue to be registered on jumpcloud.

We add this lambda to periodically clean up those registered systems on
jumpcloud.