### PR TITLE
Add subnet param

### DIFF
--- a/cf_templates/ec2.yml
+++ b/cf_templates/ec2.yml
@@ -105,8 +105,12 @@ Parameters:
   OwnerEmail:
     Description: The owner's email address for this resource (i.e. jsmith@sagebase.org)
     Type: String
+  AMIId:
+    Description: ID of the AMI to deploy
+    Type: String
 Conditions:
   PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
+  HasAMIId: !Not [!Equals ["", !Ref AMIId]]
 Mappings:
   AWSInstanceType2Arch:
     t1.micro:
@@ -433,13 +437,7 @@ Resources:
                    - !Ref JcServiceApiKey
                    - "' -d '{\"op\": \"add\",\"type\": \"system\",\"id\": \"'$JC_SYSTEM_ID'\"}'"
     Properties:
-      ImageId: !FindInMap
-        - AWSRegionArch2AMI
-        - !Ref 'AWS::Region'
-        - !FindInMap
-          - AWSInstanceType2Arch
-          - !Ref InstanceType
-          - Arch
+      ImageId: !If [HasAMIId, !Ref AMIId, !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, !Ref InstanceType, Arch]]]
       InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
       NetworkInterfaces:

--- a/cf_templates/ec2.yml
+++ b/cf_templates/ec2.yml
@@ -108,6 +108,7 @@ Parameters:
   AMIId:
     Description: ID of the AMI to deploy
     Type: String
+    Default: ""
 Conditions:
   PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
   HasAMIId: !Not [!Equals ["", !Ref AMIId]]

--- a/provision_utils.sh
+++ b/provision_utils.sh
@@ -14,6 +14,10 @@ function provision_ec2 {
   local l_project=$3
   local l_instance_type=$4
   local l_cf_template=$5
+  local l_subnet="PrivateSubnet"
+  if [ "$6" != "" ]; then
+    l_subnet=$6
+  fi
   local l_provision_cmd="aws cloudformation create-stack \
   --stack-name $l_stack_name \
   --capabilities CAPABILITY_NAMED_IAM \
@@ -22,7 +26,7 @@ function provision_ec2 {
   --template-body file://cf_templates/$l_cf_template \
   --parameters \
   ParameterKey=VpcName,ParameterValue="computevpc" \
-  ParameterKey=VpcSubnet,ParameterValue="PrivateSubnet" \
+  ParameterKey=VpcSubnet,ParameterValue="$l_subnet" \
   ParameterKey=KeyName,ParameterValue="scicomp" \
   ParameterKey=Department,ParameterValue=\"$l_department\" \
   ParameterKey=Project,ParameterValue=\"$l_project\" \

--- a/provision_utils.sh
+++ b/provision_utils.sh
@@ -14,10 +14,7 @@ function provision_ec2 {
   local l_project=$3
   local l_instance_type=$4
   local l_cf_template=$5
-  local l_subnet="PrivateSubnet"
-  if [ "$6" != "" ]; then
-    l_subnet=$6
-  fi
+  local l_subnet=${6:-"PrivateSubnet"}
   local l_provision_cmd="aws cloudformation create-stack \
   --stack-name $l_stack_name \
   --capabilities CAPABILITY_NAMED_IAM \


### PR DESCRIPTION
I would like the ability to use the auto-provisioner to provision an instance in the public subnet. From what I see the ec2.yml supports it. This PR surfaces the parameter to the provisioning function so it can be used in create_cf_stack.sh.