### PR TITLE
Update AWS developer group permissions

### DIFF
--- a/cf_templates/accounts.yml
+++ b/cf_templates/accounts.yml
@@ -36,6 +36,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
+        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
         - !Ref AWSIAMDynamoDenyDeletePolicy
         - !Ref AWSIAMRdsDenyDeletePolicy


### PR DESCRIPTION
PowerUserAccess policy is too limited when accessing IAM.  It only
allows viewing roles but does not allow viewing groups, policies
or users.  Adding 'IAMReadOnlyAccess' will provide view only access
IAM info.