### PR TITLE
Delete the synapse external bucket stack

### DIFF
--- a/auto-provision/DeleteSynapseExternalBucket.sh
+++ b/auto-provision/DeleteSynapseExternalBucket.sh
@@ -1,0 +1,10 @@
+# Script to deprovision Synapse External Bucket and related CF Stack
+# !! WARNING !! This script will permanently delete the S3 bucket
+# Usage:  ./DeleteSynapseExternalBucket.sh $STACK_NAME
+#!/usr/bin/env bash
+set -e
+
+STACK_NAME=$1
+SYNAPSE_BUCKET_NAME=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-SynapseExternalBucket'].Value" --output text)
+aws s3 rb s3://$SYNAPSE_BUCKET_NAME --force
+aws cloudformation delete-stack --stack-name $STACK_NAME


### PR DESCRIPTION
This script is for deleting the Synapse external bucket and
the related stack that provisioned that bucket.  It is meant
to be run manually using the admin role.