### PR TITLE
Make bucket encryption optional

### DIFF
--- a/templates/SynapseExternalBucket.yaml
+++ b/templates/SynapseExternalBucket.yaml
@@ -8,14 +8,35 @@ Parameters:
       - true
       - false
     Default: false
+  EncryptBucket:
+    Type: String
+    Description: true to encrypt bucket, false (default) for no encryption
+    AllowedValues:
+      - true
+      - false
+    Default: false
   SynapseUserName:
     Type: String
     Description: Synapse user for read-write bucket
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
+  EnableEncryption: !Equals [!Ref EncryptBucket, true]
+  DisableEncryption: !Not [!Condition EnableEncryption]
 Resources:
   SynapseExternalBucket:
     Type: "AWS::S3::Bucket"
+    Condition: DisableEncryption
+    Properties:
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: '3000'
+  SynapseEncryptedExternalBucket:
+    Type: "AWS::S3::Bucket"
+    Condition: EnableEncryption
     Properties:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -32,7 +53,7 @@ Resources:
   ExternalBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:
-      Bucket: !Ref SynapseExternalBucket
+      Bucket: !If [EnableEncryption, !Ref SynapseEncryptedExternalBucket, !Ref SynapseExternalBucket]
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -42,7 +63,7 @@ Resources:
             Principal:
               AWS: "325565585839"
             Action: "s3:ListBucket"
-            Resource: !GetAtt SynapseExternalBucket.Arn
+            Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
           -
             Sid: "WriteAccess"
             Effect: "Allow"
@@ -51,10 +72,16 @@ Resources:
             Action:
               - !If [AllowWrite, "s3:*GetObject*", "s3:GetObject*"]
               - "s3:*MultipartUpload*"
-            Resource: !Sub ${SynapseExternalBucket.Arn}/*
+            Resource: !If [EnableEncryption, !Sub "${SynapseEncryptedExternalBucket.Arn}/*", !Sub "${SynapseExternalBucket.Arn}/*"]
 Outputs:
   SynapseExternalBucket:
+    Condition: DisableEncryption
     Value: !Ref SynapseExternalBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseExternalBucket'
+  SynapseEncryptedExternalBucket:
+    Condition: EnableEncryption
+    Value: !Ref SynapseEncryptedExternalBucket
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseExternalBucket'
   SynapseUserName:


### PR DESCRIPTION
Create bucket without encryption by default.  Encryption can be enabled
by setting the parameter EncryptBucket="true"