### PR TITLE
fix synapse uploading of owner.txt file

### DIFF
--- a/auto-provision/SynapseExternalBucketHelper.sh
+++ b/auto-provision/SynapseExternalBucketHelper.sh
@@ -8,7 +8,7 @@ STACK_NAME=$1
 SYNAPSE_BUCKET_NAME=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-SynapseExternalBucket'].Value" --output text)
 SYNAPSE_USER_NAME=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-SynapseUserName'].Value" --output text)
 echo "$SYNAPSE_USER_NAME" > owner.txt
-aws s3 cp --sse aws:kms owner.txt s3://$SYNAPSE_BUCKET_NAME/
+aws s3 cp owner.txt s3://$SYNAPSE_BUCKET_NAME/
 
 # Send email to the bucket owner
 COMMITTER_EMAIL="$(git log -2 $TRAVIS_COMMIT --pretty="%cE"|grep -v -m1 noreply@github.com)"


### PR DESCRIPTION
Apparently you can upload an encrypted file to a non-encrypted
bucket.  Change to not specify encryption so file is uploaded
without encryption when uploading to non-encrypted bucket.