### PR TITLE
Give developers AWS batch access

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -47,6 +47,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        - arn:aws:iam::aws:policy/AWSBatchFullAccess
         - !Ref AWSIAMEnforceMfaPolicy
         - !Ref AWSIAMDynamoDenyDeletePolicy
         - !Ref AWSIAMRdsDenyDeletePolicy


### PR DESCRIPTION
AWS Batch doesn't work for Thomas, it just hangs when attempting
to create a batch.  We think it's because the Developers group is
lacking the permissions.  Provide full batch access to the group
as a test.