### PR TITLE
add hook to setup synapse external bucket

### DIFF
--- a/auto-provision/SynapseExternalBucketHelper.sh
+++ b/auto-provision/SynapseExternalBucketHelper.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+# !!!!  This script is deprecated, use the scepter synapse_external_bucket hook instead !!!!
 
 # Run after execution of SynapseExternalBucket.yaml template
 
@@ -7,11 +8,11 @@ set -e
 STACK_NAME=$1
 SYNAPSE_BUCKET_NAME=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-SynapseExternalBucket'].Value" --output text)
 SYNAPSE_USER_NAME=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-SynapseUserName'].Value" --output text)
+OWNER_EMAIL=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-$STACK_NAME-OwnerEmail'].Value" --output text)
 echo "$SYNAPSE_USER_NAME" > owner.txt
 aws s3 cp owner.txt s3://$SYNAPSE_BUCKET_NAME/
 
 # Send email to the bucket owner
-COMMITTER_EMAIL="$(git log -2 $TRAVIS_COMMIT --pretty="%cE"|grep -v -m1 noreply@github.com)"
-aws ses send-email --to "$COMMITTER_EMAIL" --subject "Scicomp Automated Provisioning" \
+aws ses send-email --to "$OWNER_EMAIL" --subject "Scicomp Automated Provisioning" \
 --text "An S3 bucket has been provisioned on your behalf. The bucket name is $SYNAPSE_BUCKET_NAME" \
 --from "aws.scicomp@sagebase.org"

--- a/config/prod/test-kdaily-encryptedexternals3.yaml
+++ b/config/prod/test-kdaily-encryptedexternals3.yaml
@@ -8,6 +8,8 @@ parameters:
   SynapseUserName: "kdaily"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
+  # Bucket owner's email address
+  OwnerEmail: kenneth.daily@sagebase.org
 hooks:
   after_create:
     - !cmd "auto-provision/SynapseExternalBucketHelper.sh test1-kdaily-encryptedexternals3"

--- a/config/prod/test-kdaily-encryptedexternals6.yaml
+++ b/config/prod/test-kdaily-encryptedexternals6.yaml
@@ -8,6 +8,8 @@ parameters:
   SynapseUserName: "kdaily"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
+  # Bucket owner's email address
+  OwnerEmail: khai.do@sagebase.org
 hooks:
   after_create:
     - !cmd "auto-provision/SynapseExternalBucketHelper.sh test-kdaily-encryptedexternals6"

--- a/config/prod/test-kdaily-unencryptedexternals3.yaml
+++ b/config/prod/test-kdaily-unencryptedexternals3.yaml
@@ -8,6 +8,8 @@ parameters:
   SynapseUserName: "kdaily"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "false"
+  # Bucket owner's email address
+  OwnerEmail: kenneth.daily@sagebase.org
 hooks:
   after_create:
     - !cmd "auto-provision/SynapseExternalBucketHelper.sh test1-kdaily-unencryptedexternals3"

--- a/config/prod/test-kdaily-unencryptedexternals5.yaml
+++ b/config/prod/test-kdaily-unencryptedexternals5.yaml
@@ -8,6 +8,8 @@ parameters:
   SynapseUserName: "kdaily"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "false"
+  # Bucket owner's email address
+  OwnerEmail: khai.do@sagebase.org
 hooks:
   after_create:
     - !cmd "auto-provision/SynapseExternalBucketHelper.sh test-kdaily-unencryptedexternals5"

--- a/hooks/synapse_external_bucket.py
+++ b/hooks/synapse_external_bucket.py
@@ -1,0 +1,158 @@
+import logging
+
+from sceptre.hooks import Hook
+from botocore.exceptions import ClientError
+
+"""
+The purpose of this hook is to run additional setup after creating
+a Synapse external bucket.  For more information please refer to the
+[synapse external bucket documention](http://docs.synapse.org/articles/custom_storage_location.html)
+
+Does the following after creation of the bucket:
+* Upload an owner.txt file to the bucket.
+* Send an email to the bucket owner with the bucket info.
+
+Example:
+
+    template_path: templates/SynapseExternalBucket.yaml
+    stack_name: GatesKI-TestStudy
+    parameters:
+      # true for read-write bucket, false (default) for read-only bucket
+      AllowWriteBucket: "true"
+      # Synapse username
+      SynapseUserName: "jsmith"
+      # true to encrypt bucket, false (default) for no encryption
+      EncryptBucket: "true"
+      # Bucket owner's email address
+      OwnerEmail: jsmith@sagebase.org
+    hooks:
+      after_create:
+        - !synapse_external_bucket
+
+"""
+class SynapseExternalBucket(Hook):
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    def __init__(self, *args, **kwargs):
+        super(SynapseExternalBucket, self).__init__(*args, **kwargs)
+
+    def run(self):
+        """
+        run is the method called by Sceptre. It should carry out the work
+        intended by this hook.
+        """
+        synapse_username = self.stack_config['parameters']['SynapseUserName']
+        owner_email = self.stack_config['parameters']['OwnerEmail']
+
+        synapse_bucket = self.get_synapse_bucket()
+        self.create_owner_file(synapse_username, synapse_bucket)
+        self.email_owner(owner_email, synapse_bucket)
+
+
+    def get_synapse_bucket(self):
+        client = self.connection_manager.boto_session.client('cloudformation')
+
+        try:
+            response = client.list_exports()
+            stack_name = self.stack_config['stack_name']
+            export_key = self.environment_config['region'] + '-' + stack_name + '-' + 'SynapseExternalBucket'
+            export_val = self.find_export_value(response, export_key)
+            return export_val
+        except ClientError as e:
+            self.logger.error(e.response['Error']['Message'])
+
+    def find_export_value(self, json, key):
+        for export in json['Exports']:
+            if export['Name'] == key:
+                return export['Value']
+
+        raise UndefinedExportException("Export not found: " + key)
+
+    def create_owner_file(self, synapse_username, synapse_bucket):
+        client = self.connection_manager.boto_session.client('s3')
+        filename = 'owner.txt'
+        try:
+            client.put_object(Body=synapse_username.encode('UTF-8'),
+                              Bucket=synapse_bucket,
+                              Key=filename)
+        except ClientError as e:
+            self.logger.error(e.response['Error']['Message'])
+        else:
+            self.logger.info("Created " + synapse_bucket + "/" + filename),
+
+
+    def email_owner(self, owner_email, synapse_bucket):
+        client = self.connection_manager.boto_session.client('ses')
+
+        # This address must be verified with Amazon SES.
+        SENDER = "AWS Scicomp <aws.scicomp@sagebase.org>"
+
+        # if SES is still in the sandbox, this address must be verified.
+        RECIPIENT = owner_email
+
+        # Specify a configuration set. If you do not want to use a configuration
+        # set, comment the following variable, and the
+        # ConfigurationSetName=CONFIGURATION_SET argument below.
+        # CONFIGURATION_SET = "ConfigSet"
+
+        # If necessary, replace us-west-2 with the AWS Region you're using for Amazon SES.
+        # AWS_REGION = "us-west-2"
+
+        # The subject line for the email.
+        SUBJECT = "Scicomp Automated Provisioning"
+
+        # The email body for recipients with non-HTML email clients.
+        BODY_TEXT = ("An S3 bucket has been provisioned on your behalf. "
+                     "The bucket name is " + synapse_bucket)
+
+        # The HTML body of the email.
+        BODY_HTML1 = """<html>
+        <head></head>
+        <body>
+          <p>"""
+        BODY_HTML2 = """</p>
+        </body>
+        </html>
+        """
+
+        # The character encoding for the email.
+        CHARSET = "UTF-8"
+
+        try:
+            #Provide the contents of the email.
+            response = client.send_email(
+                Destination={
+                    'ToAddresses': [
+                        RECIPIENT,
+                    ],
+                },
+                Message={
+                    'Body': {
+                        'Html': {
+                            'Charset': CHARSET,
+                            'Data': BODY_HTML1 + BODY_TEXT + BODY_HTML2,
+                        },
+                        'Text': {
+                            'Charset': CHARSET,
+                            'Data': BODY_TEXT,
+                        },
+                    },
+                    'Subject': {
+                        'Charset': CHARSET,
+                        'Data': SUBJECT,
+                    },
+                },
+                Source=SENDER,
+                # If you are not using a configuration set, comment or delete the
+                # following line
+                # ConfigurationSetName=CONFIGURATION_SET,
+            )
+        except ClientError as e:
+            self.logger.error(e.response['Error']['Message'])
+        else:
+            self.logger.info("Email sent! Message ID:" + response['MessageId']),
+
+
+class UndefinedExportException(Exception):
+    pass

--- a/templates/SynapseExternalBucket.yaml
+++ b/templates/SynapseExternalBucket.yaml
@@ -18,6 +18,9 @@ Parameters:
   SynapseUserName:
     Type: String
     Description: Synapse user for read-write bucket
+  OwnerEmail:
+    Type: String
+    Description: The bucket owner's email address
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
   EnableEncryption: !Equals [!Ref EncryptBucket, true]
@@ -87,3 +90,7 @@ Outputs:
     Value: !Ref SynapseUserName
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseUserName'
+  OwnerEmail:
+    Value: !Ref OwnerEmail
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'


### PR DESCRIPTION
* Sceptre hook to setup external bucket which will replace the
  SynapseExternalBucketHelper.sh script.
* Instead of searching in git log for committer email just have
  the user specify the email (OwnerEmail) to send the bucket info to.
  Relying on the email in git log can be error prone, people may not
  even setup an email in their git config.
* Make SynapseExternalBucketHelper.sh script compatible until it gets
  removed
* Update existing synapse bucket deployments with OwnerEmail parameter