### PR TITLE
add config for testing ki rally manager ec2

### DIFF
--- a/config/prod/test-ki-rally-manager-ec2.yaml
+++ b/config/prod/test-ki-rally-manager-ec2.yaml
@@ -13,9 +13,9 @@ parameters:
   # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
   InstanceType: "t2.micro"
   # Name of an existing VPC subnet to run the instance in
-  VpcSubnet: "PublicSubnet"
+  VpcSubnet: "PrivateSubnet"
   # Name of an existing EC2 KeyPair to enable SSH access to the instance
-  KeyName: test-ki-rally-manager"
+  KeyName: "test-ki-rally-manager"
 
    # Integration with our jumpcloud directory service (do not change)
   JcConnectKey: !ssm /infra/JcConnectKey

--- a/config/prod/test-ki-rally-manager-ec2.yaml
+++ b/config/prod/test-ki-rally-manager-ec2.yaml
@@ -1,0 +1,26 @@
+# Provision an EC2 instance
+template_path: templates/managed-ec2.yaml
+stack_name: test-ki-rally-manager-ec2
+dependencies:
+  - peer-vpn-computevpc
+parameters:
+  # The Sage deparment for this resource
+  Department: "Systems Biology"
+  # The Sage project this resource will be used for
+  Project: "Gates HBGDki"
+  # The resource owner
+  OwnerEmail: "kenneth.daily@sagebase.org"
+  # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
+  InstanceType: "t2.micro"
+  # Name of an existing VPC subnet to run the instance in
+  VpcSubnet: "PublicSubnet"
+  # Name of an existing EC2 KeyPair to enable SSH access to the instance
+  KeyName: test-ki-rally-manager"
+
+   # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm /infra/JcConnectKey
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+  JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+hooks:
+  after_create:
+    - !notify_ec2

--- a/config/prod/test-ki-rally-manager-ec2.yaml
+++ b/config/prod/test-ki-rally-manager-ec2.yaml
@@ -12,12 +12,7 @@ parameters:
   OwnerEmail: "kenneth.daily@sagebase.org"
   # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
   InstanceType: "t2.micro"
-  # Name of an existing VPC subnet to run the instance in
-  VpcSubnet: "PrivateSubnet"
-  # Name of an existing EC2 KeyPair to enable SSH access to the instance
-  KeyName: "test-ki-rally-manager"
-
-   # Integration with our jumpcloud directory service (do not change)
+  # Integration with our jumpcloud directory service (do not change)
   JcConnectKey: !ssm /infra/JcConnectKey
   JcServiceApiKey: !ssm /infra/JcServiceApiKey
   JcSystemsGroupId: !ssm /infra/JcSystemsGroupId


### PR DESCRIPTION
This is a testing ec2 for a Gates ki project. It will be used with Synapse workflows to connect an external database with an evaluation queue to manage the creation of Synapse objects (projects, teams, tables) to support Gates Foundation HBGDki rallies and sprints.