### PR TITLE
add config for ec2 for bsmn pipeline

### DIFF
--- a/config/prod/test-bsmn-cfncluster-ec2.yaml
+++ b/config/prod/test-bsmn-cfncluster-ec2.yaml
@@ -1,0 +1,22 @@
+# Provision an EC2 instance
+template_path: templates/managed-ec2.yaml
+stack_name: test-bsmn-cfncluster-ec2
+dependencies:
+  - peer-vpn-computevpc
+parameters:
+  # The Sage deparment for this resource
+  Department: "Systems Biology"
+  # The Sage project this resource will be used for
+  Project: "BSMN"
+  # The resource owner
+  OwnerEmail: "kenneth.daily@sagebase.org"
+  AMIId: "ami-0d08839fb598a678d"
+  # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
+  InstanceType: "t2.large"
+  # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm /infra/JcConnectKey
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+  JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+hooks:
+  after_create:
+    - !notify_ec2


### PR DESCRIPTION
A privately accessible ec2 for testing a cfncluster installation.