### PR TITLE
[IT-423] allow consultants access to agora logs

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -148,6 +148,47 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/job-function/Billing
         - !Ref AWSIAMOrganizationsFullAccessPolicy
+  # resources for logging services
+  AWSIAMSumoLogicUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Groups:
+        - !Ref AWSIAMLoggingServiceGroup
+  AWSIAMSumoLogicUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref AWSIAMSumoLogicUser
+  IAMLoggingServiceManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - 's3:GetObject'
+              - 's3:GetObjectVersion'
+              - 's3:ListBucketVersions'
+              - 's3:ListBucket'
+            Effect: Allow
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::elasticbeanstalk-'
+                  - !Ref AWS::Region
+                  - '-'
+                  - !Ref AWS::AccountId
+                  - '/*'
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::elasticbeanstalk-'
+                  - !Ref AWS::Region
+                  - '-'
+                  - !Ref AWS::AccountId
+  AWSIAMLoggingServiceGroup:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      ManagedPolicyArns:
+        - !Ref IAMLoggingServiceManagedPolicy
   # policy to enforce MFA
   AWSIAMEnforceMfaPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -251,6 +292,18 @@ Resources:
               BoolIfExists:
                 'aws:MultiFactorAuthPresent': 'false'
 Outputs:
+  AWSIAMSumoLogicUser:
+    Value: !Ref AWSIAMSumoLogicUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SumoLogicUser'
+  AWSIAMSumoLogicUserAccessKey:
+    Value: !Ref AWSIAMSumoLogicUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SumoLogicUserAccessKey'
+  AWSIAMSumoLogicUserSecretAccessKey:
+    Value: !GetAtt AWSIAMSumoLogicUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SumoLogicUserSecretAccessKey'
   AWSIAMEnforceMfaPolicy:
     Value: !Ref AWSIAMEnforceMfaPolicy
     Export:


### PR DESCRIPTION
The idea to resolving issue IT-423 is to send Agora logs to an
external log analysis service (sumologic) and give consultants
access to the logs in sumologic instead of in the scicomp
AWS account.