### PR TITLE
Revert "fix deployment of RotateCredentials.yaml"

### DIFF
--- a/config/prod/RotateCredentials.yaml
+++ b/config/prod/RotateCredentials.yaml
@@ -11,4 +11,4 @@ parameters:
   SendReport: "true"
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/RotateCredentials.yaml --create-dirs -o remote-templates/RotateCredentials.yaml"
+    - !cmd "curl https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/RotateCredentials.yaml --create-dirs -o remote-templates/RotateCredentials.yaml"


### PR DESCRIPTION
This reverts commit 2a176c165f70a1eaea0525c0aeaca0f34cf50f2d.
RotateCredentials has been restored on git with PR https://github.com/Sage-Bionetworks/aws-infra/pull/79