### PR TITLE
Add a batch developer group

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -49,6 +49,7 @@ Resources:
       UserName: thomas.yu@sagebase.org
       Groups:
         - !Ref AWSIAMAllUsersGroup
+        - !Ref AWSIAMBatchDeveloperUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -79,6 +80,11 @@ Resources:
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         - !Ref AWSIAMDynamoDenyDeletePolicy
         - !Ref AWSIAMRdsDenyDeletePolicy
+  AWSIAMBatchDeveloperUsersGroup:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSBatchFullAccess
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
     Properties:


### PR DESCRIPTION
Due to the limitations of batch policies[1] we cannot scope user access
to specific actions on specific batch jobs.  Therefore we need to provide
broder access to make it usable to a batch developer.  Adding a batch
developer group for Tom so he can develop and trigger batch jobs from
the AWS console.

Note-this group would have access to all batch resources not just the
ones they created.

[1] https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html