### PR TITLE
Provide William Poehlman with read-only access to scicomp account

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -63,6 +63,15 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+  AWSIAMWilliamPoehlman:
+    Type: 'AWS::IAM::User'
+    Properties:
+      UserName: william.poehlman@sagebase.org
+      Groups:
+        - !Ref AWSIAMAllUsersGroup
+      LoginProfile:
+        Password: !Ref InitNewUserPassword
+        PasswordResetRequired: true
   AWSIAMAaronHaydenUser:
     Type: 'AWS::IAM::User'
     Properties:


### PR DESCRIPTION
Access will be used to monitor performance of toil cluster so that we can fine-tune workflow performance.  