### PR TITLE
Give Tess access to Resource Groups

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -60,6 +60,7 @@ Resources:
       UserName: tess.thyer@sagebase.org
       Groups:
         - !Ref AWSIAMAllUsersGroup
+        - !Ref AWSIAMResourceGroupsUsersGroup
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
@@ -187,6 +188,11 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess
         - !Ref AWSIAMEnforceMfaPolicy
+  AWSIAMResourceGroupsUsersGroup:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ResourceGroupsandTagEditorFullAccess
   AWSIAMBillingManagersGroup:
     Type: 'AWS::IAM::Group'
     Properties:


### PR DESCRIPTION
Cloudformation does not support Resource Groups[1] feature
yet so we give Tess access to manually setup resource groups
from the AWS console

[1] https://docs.aws.amazon.com/ARG/latest/userguide/welcome.html