### PR TITLE
gateway vpc endpoint for computevpc and snowflakevpc

### DIFF
--- a/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -1,0 +1,10 @@
+template_path: gateway-vpc-endpoint.yaml
+stack_name: s3-computevpc-gateway-vpc-endpoint
+dependencies:
+  - prod/computevpc.yaml
+parameters:
+  VpcName: computevpc
+  ServiceName: com.amazonaws.us-east-1.s3
+hooks:
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -1,4 +1,4 @@
-template_path: gateway-vpc-endpoint.yaml
+template_path: remote/gateway-vpc-endpoint.yaml
 stack_name: s3-computevpc-gateway-vpc-endpoint
 dependencies:
   - prod/computevpc.yaml

--- a/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -6,5 +6,7 @@ parameters:
   VpcName: computevpc
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
   before_update:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -1,0 +1,10 @@
+template_path: gateway-vpc-endpoint.yaml
+stack_name: s3-snowflakevpc-gateway-vpc-endpoint
+dependencies:
+  - prod/snowflakevpc.yaml
+parameters:
+  VpcName: snowflakevpc
+  ServiceName: com.amazonaws.us-east-1.s3
+hooks:
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -6,5 +6,7 @@ parameters:
   VpcName: snowflakevpc
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
   before_update:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -1,4 +1,4 @@
-template_path: gateway-vpc-endpoint.yaml
+template_path: remote/gateway-vpc-endpoint.yaml
 stack_name: s3-snowflakevpc-gateway-vpc-endpoint
 dependencies:
   - prod/snowflakevpc.yaml


### PR DESCRIPTION
Setup a gateway vpc endpoint so that EC2 instances can directly access
other resources in the same VPC S3 buckets instead of having to go out
to the internet to access the same resources. This will reduce network
latency and cost since the EC2 doesn't need to go out thru the NAT
gateway.

This depends PR https://github.com/Sage-Bionetworks/aws-infra/pull/171