### PR TITLE
Add DescribeTags to AWSCapacityReservationPolicy

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -345,6 +345,7 @@ Resources:
               - ec2:CancelCapacityReservation
               - ec2:CreateCapacityReservation
               - ec2:DescribeCapacityReservations
+              - ec2:DescribeTags
               - ec2:GetCapacityReservationUsage
               - ec2:ModifyCapacityReservation
               - ec2:ModifyInstanceCapacityReservationAttributes


### PR DESCRIPTION
Add the ability to describe tags so that when assuming AWSCapacityReservationPolicy, one may look up the tags for an instance id. These tags will be applied to a new capacity reservation being made.