### PR TITLE
permit sandbox users to view scicomp's cloudwatch (#208)

### DIFF
--- a/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -1,0 +1,10 @@
+template_path: "remote/cloudwatch-cross-account-sharing.yaml"
+stack_name: "cloudWatch-cross-account-sharing"
+parameters:
+  MonitoringAccountIds:
+    - "563295687221"  # org-sagebase-sandbox
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"


### PR DESCRIPTION
Allow users in org-sagebase-sandbox account to view org-sagebase-scicomp
account's cloudwatch dashboard and logs.
This depends on PR https://github.com/Sage-Bionetworks/aws-infra/pull/218