### PR TITLE
Change Sceptre Hooks to before_launch

### DIFF
--- a/config/prod/AccountAlertTopics.yaml
+++ b/config/prod/AccountAlertTopics.yaml
@@ -11,4 +11,4 @@ parameters:
   SlackChannel: "#infra-notices"
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"

--- a/config/prod/AccountAlertTopics.yaml
+++ b/config/prod/AccountAlertTopics.yaml
@@ -10,5 +10,5 @@ parameters:
   SlackWebhookURL: !ssm /infra/SlackWebhookUrl
   SlackChannel: "#infra-notices"
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/AccountAlertTopics.yaml --create-dirs -o templates/remote/AccountAlertTopics.yaml"

--- a/config/prod/bootstrap.yaml
+++ b/config/prod/bootstrap.yaml
@@ -1,5 +1,5 @@
 template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"

--- a/config/prod/bootstrap.yaml
+++ b/config/prod/bootstrap.yaml
@@ -2,4 +2,4 @@ template_path: remote/bootstrap.yaml
 stack_name: bootstrap
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/bootstrap.yaml --create-dirs -o templates/remote/bootstrap.yaml"

--- a/config/prod/cfn-cr-saml-provider.yaml
+++ b/config/prod/cfn-cr-saml-provider.yaml
@@ -6,4 +6,4 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-cr-saml-provider/master/cfn-cr-saml-provider.yaml --create-dirs -o templates/remote/cfn-cr-saml-provider.yaml"

--- a/config/prod/cfn-s3objects-macro.yaml
+++ b/config/prod/cfn-s3objects-macro.yaml
@@ -4,6 +4,6 @@ dependencies:
   - "prod/bootstrap.yaml"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"

--- a/config/prod/cfn-s3objects-macro.yaml
+++ b/config/prod/cfn-s3objects-macro.yaml
@@ -3,7 +3,5 @@ stack_name: "cfn-s3objects-macro"
 dependencies:
   - "prod/bootstrap.yaml"
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cfn-s3objects-macro.yaml --create-dirs -o templates/remote/cfn-s3objects-macro.yaml"

--- a/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -5,6 +5,6 @@ parameters:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"

--- a/config/prod/cloudwatch-cross-account-sharing.yaml
+++ b/config/prod/cloudwatch-cross-account-sharing.yaml
@@ -4,7 +4,5 @@ parameters:
   MonitoringAccountIds:
     - "563295687221"  # org-sagebase-sandbox
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/cloudwatch-cross-account-sharing.yaml --create-dirs -o templates/remote/cloudwatch-cross-account-sharing.yaml"

--- a/config/prod/computevpc.yaml
+++ b/config/prod/computevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: computevpc
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"

--- a/config/prod/computevpc.yaml
+++ b/config/prod/computevpc.yaml
@@ -4,5 +4,5 @@ parameters:
   VpcSubnetPrefix: "10.5"
   VpcName: computevpc
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"

--- a/config/prod/essentials.yaml
+++ b/config/prod/essentials.yaml
@@ -6,5 +6,5 @@ parameters:
   OperatorEmail: aws.scicomp@sagebase.org
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"

--- a/config/prod/essentials.yaml
+++ b/config/prod/essentials.yaml
@@ -7,4 +7,4 @@ parameters:
   VpcPeeringRequesterAwsAccountId: !ssm /infra/AdmincentralAwsAccountId
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/essentials.yaml --create-dirs -o templates/remote/essentials.yaml"

--- a/config/prod/guardduty-member.yaml
+++ b/config/prod/guardduty-member.yaml
@@ -7,4 +7,4 @@ parameters:
   InvitationId: b8b3d07074f4b54d579c4927a4b5f78e
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"

--- a/config/prod/guardduty-member.yaml
+++ b/config/prod/guardduty-member.yaml
@@ -6,5 +6,5 @@ parameters:
   MasterAccountId: !ssm /infra/SecuritycentralAwsAccountId
   InvitationId: b8b3d07074f4b54d579c4927a4b5f78e
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/GuardDutyMember.yaml --create-dirs -o templates/remote/GuardDutyMember.yaml"

--- a/config/prod/park-my-cloud.yaml
+++ b/config/prod/park-my-cloud.yaml
@@ -6,4 +6,4 @@ parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"

--- a/config/prod/park-my-cloud.yaml
+++ b/config/prod/park-my-cloud.yaml
@@ -5,5 +5,5 @@ dependencies:
 parameters:
   PMCExternalID: !ssm /infra/PMCExternalID
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/ParkMyCloud.yaml --create-dirs -o templates/remote/ParkMyCloud.yaml"

--- a/config/prod/peer-vpn-computevpc.yaml
+++ b/config/prod/peer-vpn-computevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/prod/peer-vpn-computevpc.yaml
+++ b/config/prod/peer-vpn-computevpc.yaml
@@ -6,5 +6,5 @@ parameters:
   VpcPublicRouteTable: rtb-6e7fca12
   VpnCidr: 10.1.0.0/16
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/config/prod/peer-vpn-snowflakevpc.yaml
@@ -7,4 +7,4 @@ parameters:
   VpnCidr: 10.1.0.0/16
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/prod/peer-vpn-snowflakevpc.yaml
+++ b/config/prod/peer-vpn-snowflakevpc.yaml
@@ -6,5 +6,5 @@ parameters:
   VpcPublicRouteTable: rtb-020046b1a7632fb61
   VpnCidr: 10.1.0.0/16
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"

--- a/config/prod/rotate-credentials.yaml
+++ b/config/prod/rotate-credentials.yaml
@@ -8,5 +8,5 @@ parameters:
   SenderEmail: 'it@sagebase.org'
   SendReport: 'true'
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"

--- a/config/prod/rotate-credentials.yaml
+++ b/config/prod/rotate-credentials.yaml
@@ -9,4 +9,4 @@ parameters:
   SendReport: 'true'
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/rotate-credentials.yaml --create-dirs -o templates/remote/rotate-credentials.yaml"

--- a/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -6,7 +6,5 @@ parameters:
   VpcName: computevpc
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-computevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-computevpc-gateway-endpoint.yaml
@@ -7,6 +7,6 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -6,7 +6,5 @@ parameters:
   VpcName: snowflakevpc
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
+++ b/config/prod/s3-snowflakevpc-gateway-endpoint.yaml
@@ -7,6 +7,6 @@ parameters:
   ServiceName: com.amazonaws.us-east-1.s3
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/gateway-vpc-endpoint.yaml --create-dirs -o templates/remote/gateway-vpc-endpoint.yaml"

--- a/config/prod/sage-tgw-computevpc.yaml
+++ b/config/prod/sage-tgw-computevpc.yaml
@@ -7,6 +7,6 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"

--- a/config/prod/sage-tgw-computevpc.yaml
+++ b/config/prod/sage-tgw-computevpc.yaml
@@ -6,7 +6,5 @@ parameters:
   VpcName: "computevpc"
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"

--- a/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/config/prod/sage-tgw-snowflakevpc.yaml
@@ -7,6 +7,6 @@ parameters:
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"

--- a/config/prod/sage-tgw-snowflakevpc.yaml
+++ b/config/prod/sage-tgw-snowflakevpc.yaml
@@ -6,7 +6,5 @@ parameters:
   VpcName: "snowflakevpc"
   TransitGatewayId: 'tgw-08aa3c487e457374a'   # sage-tgw transit gateway
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-attachment.yaml --create-dirs -o templates/remote/transit-gateway-attachment.yaml"

--- a/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -11,6 +11,6 @@ parameters:
   DnsDomainName: "sagebionetworks.org"
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"

--- a/config/prod/sagebionetworks-org-acm-cert.yaml
+++ b/config/prod/sagebionetworks-org-acm-cert.yaml
@@ -10,7 +10,5 @@ parameters:
   # The domain name (i.e. acme.org)
   DnsDomainName: "sagebionetworks.org"
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/acm-certificate.yaml --create-dirs -o templates/remote/acm-certificate.yaml"

--- a/config/prod/service-linked-roles.yaml
+++ b/config/prod/service-linked-roles.yaml
@@ -4,6 +4,6 @@ dependencies:
   - prod/bootstrap.yaml
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"

--- a/config/prod/service-linked-roles.yaml
+++ b/config/prod/service-linked-roles.yaml
@@ -3,7 +3,5 @@ stack_name: service-linked-roles
 dependencies:
   - prod/bootstrap.yaml
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/service-linked-roles.yaml --create-dirs -o templates/remote/service-linked-roles.yaml"

--- a/config/prod/snowflakevpc.yaml
+++ b/config/prod/snowflakevpc.yaml
@@ -4,5 +4,5 @@ parameters:
   VpcSubnetPrefix: "10.25"
   VpcName: snowflakevpc
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"

--- a/config/prod/snowflakevpc.yaml
+++ b/config/prod/snowflakevpc.yaml
@@ -5,4 +5,4 @@ parameters:
   VpcName: snowflakevpc
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"

--- a/config/prod/sumologic-role.yaml
+++ b/config/prod/sumologic-role.yaml
@@ -8,4 +8,4 @@ parameters:
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"

--- a/config/prod/sumologic-role.yaml
+++ b/config/prod/sumologic-role.yaml
@@ -7,5 +7,5 @@ parameters:
   Actions: 's3:GetObject,s3:GetObjectVersion,s3:ListBucketVersions,s3:ListBucket'
   Resource: !ssm /infra/BeanstalkBucketArn
 hooks:
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/sumologic-role.yaml --create-dirs -o templates/remote/sumologic-role.yaml"


### PR DESCRIPTION
This repo had several config files containing a `before_update` hook but not a matching `before_create` hook (see, for example, config/prod/computevpc.yaml). I tried changing the lone `before_update`'s to `before_launch`'s. I don't know enough to be sure that that is not going to have unintended consequences, so please pay extra attention to this issue in review.