### PR TITLE
Give scicop viewers read access to Doc DBs

### DIFF
--- a/templates/jumpcloud-idp.yaml
+++ b/templates/jumpcloud-idp.yaml
@@ -78,6 +78,7 @@ Resources:
       RoleName: !GetAtt ScicompViewerSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - arn:aws:iam::aws:policy/AmazonDocDBReadOnlyAccess
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
The built in "arn:aws:iam::aws:policy/ReadOnlyAccess" does not provide
enough permissions to view databases.  When read only users search
for Document DBs they get the following message:

"not authorized to perform: rds:DescribePendingMaintenanceActions with an explicit deny"

Explicity give read access to DBs.