### PR TITLE
Update viewer policy

### DIFF
--- a/templates/jumpcloud-idp.yaml
+++ b/templates/jumpcloud-idp.yaml
@@ -77,7 +77,7 @@ Resources:
       MaxSessionDuration: 28800
       RoleName: !GetAtt ScicompViewerSamlProvider.Name
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
         - arn:aws:iam::aws:policy/AmazonDocDBReadOnlyAccess
       AssumeRolePolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
The more appropriate policy for an account viewer is the
ViewOnlyAccess policy.