### PR TITLE
Revert "Give AWS developers users access to batch (#220)"

### DIFF
--- a/templates/jumpcloud-idp.yaml
+++ b/templates/jumpcloud-idp.yaml
@@ -51,7 +51,6 @@ Resources:
       RoleName: !GetAtt ScicompDeveloperSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
-        - arn:aws:iam::aws:policy/AWSBatchFullAccess
         - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-CapacityReservationPolicyArn'
         - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-ViewReportsPolicyArn'
       AssumeRolePolicyDocument:


### PR DESCRIPTION
This reverts commit 8d1d4205cfcc0e3dd8e7481490ff7fb282d4fb0c.
The power user policy already provides full batch access