### PR TITLE
elastic beanstalk view access

### DIFF
--- a/templates/jumpcloud-idp.yaml
+++ b/templates/jumpcloud-idp.yaml
@@ -79,6 +79,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
         - arn:aws:iam::aws:policy/AmazonDocDBReadOnlyAccess
+        - arn:aws:iam::aws:policy/AWSElasticBeanstalkReadOnlyAccess
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Give scicomp-viewer users access to view access to Elastic Beanstalk.
The purpose is to allow application developers to view beanstalk
application logs to make sure apps are updated and running as
expected.